### PR TITLE
Don't try to translate url parameters like {id}

### DIFF
--- a/RoutingLocalization/WorkingExample/RouteLocalization/RouteCollectionExtensions.cs
+++ b/RoutingLocalization/WorkingExample/RouteLocalization/RouteCollectionExtensions.cs
@@ -139,6 +139,11 @@ namespace WorkingExample.RouteLocalization
             var parts = url.Split(new char[] { '/' });
             foreach (var part in parts)
             {
+                // If url contains parameters like {id}, don't try to translate them.
+                // e.g. [LocalizedRoute("~/invest/{id}")]
+                if (part.StartsWith("{"))
+                    continue;
+                
                 var translatedPart = TranslatedUrls.ResourceManager.GetString(part, new System.Globalization.CultureInfo(culture));
                 if (string.IsNullOrEmpty(translatedPart))
                     throw new Exception($"Could not find translation for url part {part} for culture {culture}");


### PR DESCRIPTION
FIX to this ISSUE:
If you try to give url parameters (like {id}) to the LocalizedRoute attribute, you will get an error saying "Could not find translation for url part {id}..." and because of this, you can't use parameters on LocalizedRoute's.